### PR TITLE
Update iptenotebook.rb

### DIFF
--- a/ipteditor-modules/iptenotebook.rb
+++ b/ipteditor-modules/iptenotebook.rb
@@ -83,7 +83,7 @@ class IPTENotebook < Gtk::Notebook
 		case p.class.to_s
 		when 'String'
 			i = @paginas.index(p)
-		when 'Fixnum'
+		when 'Integer'
 			i = p
 		else
 			i = nil


### PR DESCRIPTION
Fix for https://github.com/Intika-Linux-Firewall/Iptables-Editor-Gui/issues/3
Fixnum is deprecated, should use Integer instead.